### PR TITLE
Add timeout option to the wait-for-deployment script

### DIFF
--- a/wait-for-deployment
+++ b/wait-for-deployment
@@ -16,9 +16,9 @@ DEFAULT_TIMEOUT=60
 
 monitor_timeout() {
   local -r wait_pid="$1"
-  sleep ${timeout}
+  sleep "${timeout}"
   echo "Timeout ${timeout} exceeded" >&2
-  kill ${wait_pid}
+  kill "${wait_pid}"
 }
 
 get_generation() {
@@ -44,7 +44,7 @@ get_deployment_jsonpath() {
 }
 
 display_usage_and_exit() {
-  echo "Usage: $(basename $0) <deployment> <[timeout]>" >&2
+  echo "Usage: $(basename "$0") <deployment> <[timeout]>" >&2
   echo "Arguments:" >&2
   echo "deployment - REQUIRED: The name of the deployment the script should wait on" >&2
   echo "timeout    - OPTIONAL: How long to wait for the deployment to be available, defaults to ${DEFAULT_TIMEOUT} seconds, must be greater than 0" >&2
@@ -67,7 +67,7 @@ echo "Waiting for deployment with timeout ${timeout} seconds"
 monitor_timeout $$ &
 readonly timeout_monitor_pid=$!
 
-trap "kill ${timeout_monitor_pid}" EXIT #Stop timeout monitor
+trap 'kill ${timeout_monitor_pid}' EXIT #Stop timeout monitor
 
 generation=$(get_generation);  readonly generation
 current_generation=$(get_observed_generation)

--- a/wait-for-deployment
+++ b/wait-for-deployment
@@ -44,7 +44,7 @@ get_deployment_jsonpath() {
 }
 
 display_usage_and_exit() {
-  echo "usage: $(basename $0) <deployment> <[timeout]>" >&2
+  echo "Usage: $(basename $0) <deployment> <[timeout]>" >&2
   echo "Arguments:" >&2
   echo "deployment - REQUIRED: The name of the deployment the script should wait on" >&2
   echo "timeout    - OPTIONAL: How long to wait for the deployment to be available, defaults to ${DEFAULT_TIMEOUT} seconds, must be greater than 0" >&2
@@ -69,22 +69,24 @@ readonly timeout_monitor_pid=$!
 
 trap "kill ${timeout_monitor_pid}" EXIT #Stop timeout monitor
 
-generation=$(get_generation); readonly generation
+generation=$(get_generation);  readonly generation
+current_generation=$(get_observed_generation)
 
-echo "waiting for specified generation ${generation} to be observed"
-while [[ $(get_observed_generation) -lt ${generation} ]]; do
+echo "Expected generation for deployment ${deployment}: ${generation}"
+while [[ ${current_generation} -lt ${generation} ]]; do
   sleep .5
+  echo "Currently observed generation: ${current_generation}"
 done
-echo "specified generation observed."
+echo "Observed expected generation: ${current_generation}"
 
 replicas="$(get_replicas)"; readonly replicas
-echo "specified replicas: ${replicas}"
+echo "Expected replicas: ${replicas}"
 
-available=-1
-while [[ ${available} -ne ${replicas} ]]; do
+available=$(get_available_replicas)
+while [[ ${available} -lt ${replicas} ]]; do
   sleep .5
+  echo "Available replicas: ${available}, waiting"
   available=$(get_available_replicas)
-  echo "available replicas: ${available}"
 done
 
-echo "deployment complete."
+echo "Deployment of service ${deployment} successful. All ${available} replicas ready"

--- a/wait-for-deployment
+++ b/wait-for-deployment
@@ -10,9 +10,14 @@
 #
 set -o errexit
 set -o pipefail
-set -o nounset
 
-deployment=
+DEFAULT_TIMEOUT=60
+
+monitor_timeout() {
+  sleep ${timeout}
+  echo "Timeout ${timeout} exceeded" >&2
+  kill $1
+}
 
 get_generation() {
   get_deployment_jsonpath '{.metadata.generation}'
@@ -36,10 +41,21 @@ get_deployment_jsonpath() {
   kubectl get deployment "${deployment}" -o "jsonpath=${jsonpath}"
 }
 
-if [[ $# != 1 ]]; then
-  echo "usage: $(basename "$0") <deployment>" >&2
+if [[ $# -lt 1 ]]; then
+  echo "usage: $(basename $0) <deployment> [timeout]" >&2
   exit 1
 fi
+
+if [[ $2 -gt 0 ]]; then
+  export timeout=$2
+else 
+  export timeout=$DEFAULT_TIMEOUT
+fi
+
+echo "Waiting for deployment with timeout: ${timeout} seconds"
+
+monitor_timeout $$ &
+readonly timeout_monitor_pid=$!
 
 readonly deployment="$1"
 
@@ -60,4 +76,5 @@ while [[ ${available} -ne ${replicas} ]]; do
   echo "available replicas: ${available}"
 done
 
+kill ${timeout_monitor_pid} #Stop timeout monitor
 echo "deployment complete."

--- a/wait-for-deployment
+++ b/wait-for-deployment
@@ -10,13 +10,15 @@
 #
 set -o errexit
 set -o pipefail
+set -o nounset
 
 DEFAULT_TIMEOUT=60
 
 monitor_timeout() {
+  local -r wait_pid="$1"
   sleep ${timeout}
   echo "Timeout ${timeout} exceeded" >&2
-  kill $1
+  kill ${wait_pid}
 }
 
 get_generation() {
@@ -41,25 +43,34 @@ get_deployment_jsonpath() {
   kubectl get deployment "${deployment}" -o "jsonpath=${jsonpath}"
 }
 
-if [[ $# -lt 1 ]]; then
-  echo "usage: $(basename $0) <deployment> [timeout]" >&2
+display_usage_and_exit() {
+  echo "usage: $(basename $0) <deployment> <[timeout]>" >&2
+  echo "Arguments:" >&2
+  echo "deployment - REQUIRED: The name of the deployment the script should wait on" >&2
+  echo "timeout    - OPTIONAL: How long to wait for the deployment to be available, defaults to ${DEFAULT_TIMEOUT} seconds, must be greater than 0" >&2
   exit 1
+}
+
+if [ $# -lt 1 ] || [ $# -gt 2 ] ; then
+  display_usage_and_exit
 fi
 
-if [[ $2 -gt 0 ]]; then
-  export timeout=$2
-else 
-  export timeout=$DEFAULT_TIMEOUT
+readonly deployment="$1"
+
+declare -xr timeout=${2:-$DEFAULT_TIMEOUT}
+if [[ ${timeout} -le 0 ]]; then
+  display_usage_and_exit
 fi
 
-echo "Waiting for deployment with timeout: ${timeout} seconds"
+echo "Waiting for deployment with timeout ${timeout} seconds"
 
 monitor_timeout $$ &
 readonly timeout_monitor_pid=$!
 
-readonly deployment="$1"
+trap "kill ${timeout_monitor_pid}" EXIT #Stop timeout monitor
 
 generation=$(get_generation); readonly generation
+
 echo "waiting for specified generation ${generation} to be observed"
 while [[ $(get_observed_generation) -lt ${generation} ]]; do
   sleep .5
@@ -76,5 +87,4 @@ while [[ ${available} -ne ${replicas} ]]; do
   echo "available replicas: ${available}"
 done
 
-kill ${timeout_monitor_pid} #Stop timeout monitor
 echo "deployment complete."


### PR DESCRIPTION
Fixes https://github.com/timoreimann/kubernetes-scripts/issues/3

After looking at different options how to handle timeouts, this one seems most popular and looks ok to me

I had to remove `set -o nounset` to check unset timeout parameter
