### PR TITLE
Fix local readonly usages.

### DIFF
--- a/wait-for-deployment
+++ b/wait-for-deployment
@@ -31,9 +31,9 @@ get_available_replicas() {
 }
 
 get_deployment_jsonpath() {
-  local -r _jsonpath="$1"
+  local -r jsonpath="$1"
 
-  kubectl get deployment "${deployment}" -o "jsonpath=${_jsonpath}"
+  kubectl get deployment "${deployment}" -o "jsonpath=${jsonpath}"
 }
 
 if [[ $# != 1 ]]; then

--- a/wait-for-deployment
+++ b/wait-for-deployment
@@ -31,7 +31,7 @@ get_available_replicas() {
 }
 
 get_deployment_jsonpath() {
-  local readonly _jsonpath="$1"
+  local -r _jsonpath="$1"
 
   kubectl get deployment "${deployment}" -o "jsonpath=${_jsonpath}"
 }
@@ -43,14 +43,14 @@ fi
 
 readonly deployment="$1"
 
-readonly generation=$(get_generation)
+generation=$(get_generation); readonly generation
 echo "waiting for specified generation ${generation} to be observed"
 while [[ $(get_observed_generation) -lt ${generation} ]]; do
   sleep .5
 done
 echo "specified generation observed."
 
-readonly replicas="$(get_replicas)"
+replicas="$(get_replicas)"; readonly replicas
 echo "specified replicas: ${replicas}"
 
 available=-1

--- a/wait-for-deployment
+++ b/wait-for-deployment
@@ -37,7 +37,7 @@ get_deployment_jsonpath() {
 }
 
 if [[ $# != 1 ]]; then
-  echo "usage: $(basename $0) <deployment>" >&2
+  echo "usage: $(basename "$0") <deployment>" >&2
   exit 1
 fi
 


### PR DESCRIPTION
This fixes flawed declarations of local, readonly variables and breaks read-only variables derived from command substitutions into two lines to avoid swallowing error codes.
