### PR TITLE
trap won't kill timeout monitor in non-interactive environment

### DIFF
--- a/wait-for-deployment
+++ b/wait-for-deployment
@@ -11,6 +11,7 @@
 set -o errexit
 set -o pipefail
 set -o nounset
+set -m
 
 DEFAULT_TIMEOUT=60
 
@@ -67,7 +68,7 @@ echo "Waiting for deployment with timeout ${timeout} seconds"
 monitor_timeout $$ &
 readonly timeout_monitor_pid=$!
 
-trap 'kill -- -$$' EXIT #Stop timeout monitor
+trap 'kill -- -${timeout_monitor_pid}' EXIT #Stop timeout monitor
 
 generation=$(get_generation);  readonly generation
 current_generation=$(get_observed_generation)

--- a/wait-for-deployment
+++ b/wait-for-deployment
@@ -67,7 +67,7 @@ echo "Waiting for deployment with timeout ${timeout} seconds"
 monitor_timeout $$ &
 readonly timeout_monitor_pid=$!
 
-trap 'kill ${timeout_monitor_pid}' EXIT #Stop timeout monitor
+trap 'kill -- -$$' EXIT #Stop timeout monitor
 
 generation=$(get_generation);  readonly generation
 current_generation=$(get_observed_generation)

--- a/wait-for-deployment
+++ b/wait-for-deployment
@@ -11,6 +11,8 @@
 set -o errexit
 set -o pipefail
 set -o nounset
+# -m enables job control which is otherwise only enabled in interactive mode
+# http://unix.stackexchange.com/a/196606/73578
 set -m
 
 DEFAULT_TIMEOUT=60


### PR DESCRIPTION
if the script is run eg in a docker container without `-it` the sleep process started by the monitor wont be killed with it and so it will keep the parent process waiting
